### PR TITLE
Correcting versions of yoyo deps in example templates

### DIFF
--- a/yoyo-api/src/leiningen/new/yoyo_api/project.clj
+++ b/yoyo-api/src/leiningen/new/yoyo_api/project.clj
@@ -8,10 +8,10 @@
   :dependencies [[org.clojure/clojure "1.7.0-RC1"]
                  [jarohen/embed-nrepl "0.1.0"]
 
-                 [jarohen/yoyo "0.1.0-SNAPSHOT"]
+                 [jarohen/yoyo "0.0.1"]
 
                  [ring/ring-core "1.3.0"]
-                 [jarohen/yoyo.aleph "0.1.0-SNAPSHOT"]
+                 [jarohen/yoyo.aleph "0.0.1"]
                  [bidi "1.19.0"]
                  [ring-middleware-format "0.5.0" :exclusions [ring]]
 

--- a/yoyo-webapp/src/leiningen/new/yoyo_webapp/project.clj
+++ b/yoyo-webapp/src/leiningen/new/yoyo_webapp/project.clj
@@ -9,16 +9,16 @@
                  [org.clojure/tools.reader "0.9.2"]
                  [jarohen/embed-nrepl "0.1.0"]
 
-                 [jarohen/yoyo "0.1.0-SNAPSHOT"]
+                 [jarohen/yoyo "0.0.1"]
 
                  [ring/ring-core "1.3.2"]
-                 [jarohen/yoyo.aleph "0.1.0-SNAPSHOT"]
+                 [jarohen/yoyo.aleph "0.0.1"]
                  [bidi "1.19.0"]
                  [hiccup "1.0.5"]
                  [garden "1.2.1"]
                  [ring-middleware-format "0.5.0" :exclusions [ring]]
 
-                 [jarohen/yoyo.cljs "0.1.0-SNAPSHOT"]
+                 [jarohen/yoyo.cljs "0.0.1"]
 
                  [org.clojure/tools.logging "0.3.1"]
                  [org.slf4j/slf4j-api "1.7.9"]


### PR DESCRIPTION
Tried to test drive your templates but couldn't find the deps in Clojars. Changed the snapshot versions to fixed `0.0.1`. Hope that's right!
