### PR TITLE
Correct README documentation for 0.0.4

### DIFF
--- a/http-kit/README.org
+++ b/http-kit/README.org
@@ -21,7 +21,7 @@
   (defn make-system [latch]
     (...
      (fn [...]
-       (http/with-web-server {:handler (make-handler ...)
+       (http/with-server {:handler (make-handler ...)
                               :server-opts {:port ...
                                             ...}} ; anything else you'd pass to org.httpkit.server/run-server
          (fn [server]


### PR DESCRIPTION
`with-web-server` is now just `with-server`.
